### PR TITLE
Cap large log files (1.1 release)

### DIFF
--- a/es_logstash/changeESLogProperties.sh
+++ b/es_logstash/changeESLogProperties.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Changes the default Elasticsearch logging properties to use RollingFileAppender
+# instead of DailyRollingFileAppender. Assumptions:
+#  - the input file is the default logging.yml file from ES 0.90.9-1.3.1
+#
+
+# stop on the first error
+set -e
+
+if [ $# -ne 1 ]; then
+	echo "ERROR: missing required file name argument"
+	echo "USAGE: $0 <log4jConfigFile>"
+	exit 1
+fi
+
+LOG4J_PROPERTIES=$1
+if [ ! -f ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} does not exist"
+	exit 1
+elif [ ! -r ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} is not readable"
+	exit 1
+elif [ ! -w ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} is not writable"
+	exit 1
+fi
+
+#
+# Replace  DailyRollingFileAppender with RollingFileAppender, and configure
+# RollingFileAppender to keep a maximum of 10 log files, each no larger than 10MB
+# (a typical configuration for other zenoss containers).
+#
+sed  -i -e 's/type: dailyRollingFile/type: rollingFile/g' ${LOG4J_PROPERTIES}
+sed  -i -e 's/datePattern.*/maxFileSize: 10MB\n    maxBackupIndex: 10/g' ${LOG4J_PROPERTIES}

--- a/es_logstash/makefile
+++ b/es_logstash/makefile
@@ -24,4 +24,5 @@ tarball:
 	sed -i -e 's/^.*http.port.*$$/http.port: 9100/' /opt/elasticsearch-$(ES_VERSION)/config/elasticsearch.yml
 	sed -i -e 's/^.*cluster.name.*$$/cluster.name: elasticsearch_logstash/' /opt/elasticsearch-$(ES_VERSION)/config/elasticsearch.yml
 	cat elasticsearch-addendum.yaml >> /opt/elasticsearch-$(ES_VERSION)/config/elasticsearch.yml
+	./changeESLogProperties.sh /opt/elasticsearch-$(ES_VERSION)/config/logging.yml
 	tar czf $(TARGET)/es_logstash.tar.gz /opt

--- a/es_serviced/changeESLogProperties.sh
+++ b/es_serviced/changeESLogProperties.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Changes the default Elasticsearch logging properties to use RollingFileAppender
+# instead of DailyRollingFileAppender. Assumptions:
+#  - the input file is the default logging.yml file from ES 0.90.9-1.3.1
+#
+
+# stop on the first error
+set -e
+
+if [ $# -ne 1 ]; then
+	echo "ERROR: missing required file name argument"
+	echo "USAGE: $0 <log4jConfigFile>"
+	exit 1
+fi
+
+LOG4J_PROPERTIES=$1
+if [ ! -f ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} does not exist"
+	exit 1
+elif [ ! -r ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} is not readable"
+	exit 1
+elif [ ! -w ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} is not writable"
+	exit 1
+fi
+
+#
+# Replace  DailyRollingFileAppender with RollingFileAppender, and configure
+# RollingFileAppender to keep a maximum of 10 log files, each no larger than 10MB
+# (a typical configuration for other zenoss containers).
+#
+sed  -i -e 's/type: dailyRollingFile/type: rollingFile/g' ${LOG4J_PROPERTIES}
+sed  -i -e 's/datePattern.*/maxFileSize: 10MB\n    maxBackupIndex: 10/g' ${LOG4J_PROPERTIES}

--- a/es_serviced/makefile
+++ b/es_serviced/makefile
@@ -23,4 +23,5 @@ tarball:
 	/opt/elasticsearch-$(ES_VERSION)/bin/plugin -install mobz/elasticsearch-head
 	sed -i -e 's/^.*cluster.name.*$$/cluster.name: elasticsearch_serviced/' /opt/elasticsearch-$(ES_VERSION)/config/elasticsearch.yml
 	cat elasticsearch-addendum.yaml >> /opt/elasticsearch-$(ES_VERSION)/config/elasticsearch.yml
+	./changeESLogProperties.sh /opt/elasticsearch-$(ES_VERSION)/config/logging.yml
 	tar czf $(TARGET)/es_serviced.tar.gz /opt

--- a/opentsdb/changeHbaseLogProperties.sh
+++ b/opentsdb/changeHbaseLogProperties.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Changes the default Hbase logging properties to use RollingFileAppender
+# instead of DailyRollingFileAppender. Assumptions:
+#  - the input file is the default log4j.properties file from Hbase 0.94.16
+#  - the log4j.properties file is based on log4j 1.2.16
+#
+
+# stop on the first error
+set -e
+
+if [ $# -ne 1 ]; then
+	echo "ERROR: missing required file name argument"
+	echo "USAGE: $0 <log4jConfigFile>"
+	exit 1
+fi
+
+LOG4J_PROPERTIES=$1
+if [ ! -f ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} does not exist"
+	exit 1
+elif [ ! -r ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} is not readable"
+	exit 1
+elif [ ! -w ${LOG4J_PROPERTIES} ]; then
+	echo "ERROR: file '${LOG4J_PROPERTIES} is not writable"
+	exit 1
+fi
+
+#
+# Replace  DailyRollingFileAppender with RollingFileAppender, and configure
+# RollingFileAppender to keep a maximum of 10 log files, each no larger than 10MB
+# (a typical configuration for other zenoss containers).
+#
+# Note that we have to keep the "DRFA" identifier in the property names because
+# the hbase startup scripts specify that value.
+#
+sed  -i -e 's/Daily Rolling File Appender/Rolling File Appender/g' ${LOG4J_PROPERTIES}
+sed  -i -e 's/DailyRollingFileAppender/RollingFileAppender/g' ${LOG4J_PROPERTIES}
+sed  -i -e 's/Rollver at midnight/Rollover at 10MB/' ${LOG4J_PROPERTIES}
+sed  -i -e 's/DatePattern=.*/MaxFileSize=10MB/g' ${LOG4J_PROPERTIES}
+sed  -i -e 's/30\-day backup/Keep last 10 log files/' ${LOG4J_PROPERTIES}
+sed  -i -e 's/\#log4j.appender.DRFA.MaxBackupIndex=30/log4j.appender.DRFA.MaxBackupIndex=10/g' ${LOG4J_PROPERTIES}
+sed  -i -e 's/log4j.logger.org.apache.hadoop.hbase=DEBUG/log4j.logger.org.apache.hadoop.hbase=INFO/g' ${LOG4J_PROPERTIES}

--- a/opentsdb/makefile
+++ b/opentsdb/makefile
@@ -16,6 +16,7 @@ HBASE_VERSION := 0.94.16
 
 default: tarball
 
+
 tarball:
 	wget -qO- https://s3.amazonaws.com/pip.zenoss/binary_mirrors/hbase-$(HBASE_VERSION).tar.gz | tar -C /opt -xz
 	git clone git://github.com/OpenTSDB/opentsdb.git /opt/opentsdb
@@ -25,6 +26,7 @@ tarball:
 	cp /tmp/in/start-opentsdb.sh /opt/opentsdb/build/start-opentsdb.sh && chmod a+x /opt/opentsdb/build/start-opentsdb.sh
 	cd /opt/hbase-$(HBASE_VERSION) && patch -p0 < /tmp/in/hbase-daemon.sh.patch
 	cd /opt/hbase-$(HBASE_VERSION) && patch -p0 < /tmp/in/start-hbase.sh.patch
+	./changeHbaseLogProperties.sh /opt/hbase-$(HBASE_VERSION)/conf/log4j.properties
 	echo "export HBASE_MANAGES_ZK=true" >> /opt/hbase-$(HBASE_VERSION)/conf/hbase-env.sh
 	mkdir -p /opt/zenoss/etc/supervisor
 	cp /tmp/in/opentsdb_supervisor.conf /opt/zenoss/etc/supervisor/opentsdb_supervisor.conf


### PR DESCRIPTION
Fixes CC-1012: Limit log files sizes for isvcs HBase and ES instances to 10 files x 10MB/each