### PR TITLE
ZEN-20783 - Add JVMFLAGS to increase jute.maxbuffer size

### DIFF
--- a/isvcs-zookeeper/Dockerfile
+++ b/isvcs-zookeeper/Dockerfile
@@ -7,6 +7,7 @@ ENV ZK_PATH /opt/zookeeper-${ZK_VERSION}
 ENV ZK_DATA /var/zookeeper
 ENV EXHIBITOR_VERSION 1.5.5
 ENV EXHIBITOR_URL http://central.maven.org/maven2/com/netflix/exhibitor/exhibitor-standalone/${EXHIBITOR_VERSION}/exhibitor-standalone-${EXHIBITOR_VERSION}.jar
+ENV JVMFLAGS=-Djute.maxbuffer=5242880
 
 # Install ZooKeeper
 RUN mkdir -p /opt ${ZK_DATA} && \

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ ISVCS_NAME := serviced-isvcs
 ISVCS_VERSION     := 39-dev
 
 ZOOKEEPER_NAME := isvcs-zookeeper
-ZOOKEEPER_VERSION := 2-dev
+ZOOKEEPER_VERSION := 3-dev
 
 .PHONY: all
 all: isvcs zookeeper


### PR DESCRIPTION
Adding jute.maxbuffer size to the Dockerfile so that it is still able to be overridden in /etc/defaults/serviced.  