### PR TITLE
Update base centos image

### DIFF
--- a/isvcs-zookeeper/Dockerfile
+++ b/isvcs-zookeeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM zenoss/centos-base:1.0.1-java
+FROM zenoss/centos-base:1.0.2-java
 MAINTAINER Zenoss <dev@zenoss.com>
 
 ENV ZK_VERSION 3.4.5

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ ISVCS_NAME := serviced-isvcs
 ISVCS_VERSION     := 40-dev
 
 ZOOKEEPER_NAME := isvcs-zookeeper
-ZOOKEEPER_VERSION := 3-dev
+ZOOKEEPER_VERSION := 4-dev
 
 .PHONY: all
 all: isvcs zookeeper

--- a/serviced-isvcs/Dockerfile
+++ b/serviced-isvcs/Dockerfile
@@ -1,4 +1,4 @@
-FROM zenoss/centos-base:1.0.1-java
+FROM zenoss/centos-base:1.0.2-java
 MAINTAINER Zenoss <dev@zenoss.com>
 
 # Create mount point for isvcs resources


### PR DESCRIPTION
`ISVCS_VERSION` is not being bumped in this PR because it had been inappropriately bumped in a prior PR, and `v39` is still available for use as the next version.