### PR TITLE
ZEN-31639 OpenTSDB 2.3.0 vulnerabilities

### DIFF
--- a/build/opentsdb/makefile
+++ b/build/opentsdb/makefile
@@ -22,7 +22,7 @@ default: $(TARBALL)
 $(TARBALL):
 	echo "Building $(TARBALL) ..."
 	docker run --rm -v "$(PWD)":$(TARGET) -w $(TARGET) \
-		-e HBASE_VERSION=$(HBASE_VERSION) -e OPENTSDB_VERSION=$(OPENTSDB_VERSION) maven:3.3.3-jdk-7 \
+		-e HBASE_VERSION=$(HBASE_VERSION) -e OPENTSDB_VERSION=$(OPENTSDB_VERSION) maven:3.6.0-jdk-7 \
 		/bin/bash -c "apt-get update && apt-get -y install make autoconf patch && make build"
 
 .PHONY: build

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ TAG       := zenoss/$(IMAGENAME):$(VERSION)
 REGISTRY_VERSION := 2.3.0
 REGISTRY_TARBALL := build/registry/registry-$(REGISTRY_VERSION).tar.gz
 
-OPENTSDB_VERSION := 2.3.0
+OPENTSDB_VERSION := 2.3.1
 HBASE_VERSION := 0.94.16
 OPENTSDB_HBASE_TARBALL := build/opentsdb/opentsdb-$(OPENTSDB_VERSION)_hbase-$(HBASE_VERSION).tar.gz
 


### PR DESCRIPTION
Maven updated because we can't build the image with old maven(some Debian repos are deprecated)