### PR TITLE
CC-4332: [Part 1] Elasticsearch upgrade

### DIFF
--- a/es-serviced-addendum.yaml
+++ b/es-serviced-addendum.yaml
@@ -3,7 +3,7 @@
 #
 # Disable dynamic scripting engine to address CVE-2014-3120 (CC-997)
 #
-script.allowed_types: none
+script.allowed_types: inline
 
 #
 # Disable replication for a single-node cluster (CC-1164)


### PR DESCRIPTION
script.allowed_types requires inline option due to x-pack monitoring setup